### PR TITLE
Add PDFParsingService to DemoApplication test

### DIFF
--- a/demo/demo/src/test/java/com/nadeem/pdftodb/DemoApplicationTests.java
+++ b/demo/demo/src/test/java/com/nadeem/pdftodb/DemoApplicationTests.java
@@ -1,13 +1,21 @@
 package com.nadeem.pdftodb;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.nadeem.pdftodb.service.PDFParsingService;
 
 @SpringBootTest
 class DemoApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private PDFParsingService pdfParsingService;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(pdfParsingService);
+    }
 
 }


### PR DESCRIPTION
## Summary
- autowire `PDFParsingService` in the test suite
- assert that the service is loaded during context startup

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fce28b858832a94ca6999e09971fe